### PR TITLE
Add interactive contributor profiles in project cards

### DIFF
--- a/src/hooks/useGitHubRepo.ts
+++ b/src/hooks/useGitHubRepo.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 
-interface GitHubContributor {
+export interface GitHubContributor {
   login: string;
   contributions: number;
   avatar_url: string;


### PR DESCRIPTION
## Summary
- Implements interactive contributor profiles as requested in #7
- Contributor avatars are now clickable and redirect to GitHub profiles
- Both card and avatar scale on hover for clear visual feedback

## Changes
- Modified `src/components/ui/project-card.tsx` to add click handlers and hover effects
- Exported GitHubContributor interface from `src/hooks/useGitHubRepo.ts`
- Added tooltips showing contributor name and contribution count
- Implemented full keyboard navigation (Tab/Enter/Space)
- Added proper ARIA labels for accessibility

## Technical Details
- Avatars scale to 125% on hover while card maintains 105% scale
- Click event propagation prevented to avoid card navigation conflicts
- Tooltips appear on both hover and keyboard focus
- Removed border styling from avatar images for cleaner appearance

Fixes #7